### PR TITLE
Adding info how to install for ST3 on Mac OS X. Adding autocomment possibility.

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Comments</string>
+  <key>scope</key>
+  <string>source.ansible</string>
+  <key>settings</key>
+  <dict>
+    <key>shellVariables</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_START</string>
+        <key>value</key>
+        <string># </string>
+      </dict>
+    </array>
+  </dict>
+  <key>uuid</key>
+  <string>191ec0ea-4365-43fb-8555-48dd8db9f8a9</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -17,13 +17,18 @@ mv pchaigno-sublime-ansible-*/*.tmLanguage ~/.config/sublime-text-2/Packages/Use
 ### Sublime Text 3 (Mac OS X)
 ```
 cd /tmp
-wget -O sublime-ansible.tar.gz http://github.com/pchaigno/sublime-ansible/tarball/master
-tar -xzvf sublime-ansible.tar.gz
-zip Ansible.sublime-package pchaigno-sublime-ansible-*/*
+wget -O sublime-ansible.zip https://codeload.github.com/pchaigno/sublime-ansible/zip/master
+unzip sublime-ansible.zip
+zip -j Ansible.sublime-package sublime-ansible-master/*
 mv Ansible.sublime-package ~/Library/Application\ Support/Sublime\ Text\ 3/Installed\ Packages/
 ```
 
 ### Install and configure ApplySyntax
+```
+ApplySyntax enables automatic recognition of Ansible files, based on their location.
+Because Ansible files have a `.yml` extension, without ApplySyntax, they will be highlighted as YAML by default.
+```
+
 Installation:
 ```
 Tools -> Command Palette... -> Package Control: Install Package
@@ -44,7 +49,6 @@ And edit with syntax rules:
           {"file_name": ".*/handler/.*.yml$"},
           {"file_name": ".*/*_vars/.*.yml$"},
           {"file_name": ".*/roles/.*.yml$"},
-          {"file_name": ".*/hosts/.*$"},
           {"file_name": ".*/playbooks/.*.yml$"},
           {"file_name": ".*/.*ansible.*/.*.yml$"}
         ]

--- a/README.md
+++ b/README.md
@@ -6,11 +6,49 @@ This package provides syntax highlighting for Sublime Text 2 and 3.
 
 To install this package, please do:
 
+### Sublime Text 2
 ```
 cd /tmp
 wget -O sublime-ansible.tar.gz http://github.com/pchaigno/sublime-ansible/tarball/master
 tar -xzvf sublime-ansible.tar.gz
 mv pchaigno-sublime-ansible-*/*.tmLanguage ~/.config/sublime-text-2/Packages/User/
+```
+
+### Sublime Text 3 (Mac OS X)
+```
+cd /tmp
+wget -O sublime-ansible.tar.gz http://github.com/pchaigno/sublime-ansible/tarball/master
+tar -xzvf sublime-ansible.tar.gz
+zip Ansible.sublime-package pchaigno-sublime-ansible-*/*
+mv Ansible.sublime-package ~/Library/Application\ Support/Sublime\ Text\ 3/Installed\ Packages/
+```
+
+### Install and configure ApplySyntax
+Installation:
+```
+Tools -> Command Palette... -> Package Control: Install Package
+```
+
+Path to Configuration:
+```
+Sublime Text -> Preferences -> Package Settings -> ApplySyntax -> Settings - User
+```
+
+And edit with syntax rules:
+```
+    "syntaxes": [
+      {
+        "name": "Ansible/Ansible",
+        "rules": [
+          {"file_name": ".*/tasks/.*.yml$"},
+          {"file_name": ".*/handler/.*.yml$"},
+          {"file_name": ".*/*_vars/.*.yml$"},
+          {"file_name": ".*/roles/.*.yml$"},
+          {"file_name": ".*/hosts/.*$"},
+          {"file_name": ".*/playbooks/.*.yml$"},
+          {"file_name": ".*/.*ansible.*/.*.yml$"}
+        ]
+      },
 ```
 
 ## License


### PR DESCRIPTION
Hi, I've found that original Ansible language syntax maintainer moved from ST to Atom and informed that You're working on extending it. I've spent a little time to know how to install Your package on ST3 (on my Mac) and wanted to place this for other people who might want to do the same :-)

I've copied from original code file to enable auto comments using `cmd+/` shortcut,
